### PR TITLE
add benchmark

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -1,6 +1,9 @@
 package stats
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+)
 
 func TestMean(t *testing.T) {
 	type args struct {
@@ -25,8 +28,19 @@ func TestMean(t *testing.T) {
 	}
 }
 
-func BenchmarkMean(b *testing.B) {
+func benchmarkMean(len int, b *testing.B) {
+	s := make([]float64, len)
+	for e := 0; e <= len-1; e++ {
+		s[e] = rand.Float64()
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Mean([]float64{5.1, 5.3, 6.0, 4.2, 5.0, 5.3, 4.9, 5.1, 5.2, 5.7, 4.6})
+		Mean(s)
 	}
 }
+
+func BenchmarkMean1(b *testing.B) { benchmarkMean(1, b) }
+func BenchmarkMean2(b *testing.B) { benchmarkMean(2, b) }
+func BenchmarkMean3(b *testing.B) { benchmarkMean(10, b) }
+func BenchmarkMean4(b *testing.B) { benchmarkMean(1e3, b) }
+func BenchmarkMean5(b *testing.B) { benchmarkMean(1e6, b) }

--- a/stats_test.go
+++ b/stats_test.go
@@ -24,3 +24,9 @@ func TestMean(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkMean(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Mean([]float64{5.1, 5.3, 6.0, 4.2, 5.0, 5.3, 4.9, 5.1, 5.2, 5.7, 4.6})
+	}
+}


### PR DESCRIPTION
Added a benchmark to analyse Mean performance

goos: windows
goarch: amd64
pkg: github.com/orvend/stats
BenchmarkMean1-32       321321100                3.41 ns/op            0 B/op          0 allocs/op
BenchmarkMean2-32       285679146                4.96 ns/op            0 B/op          0 allocs/op
BenchmarkMean3-32       122280352                8.75 ns/op            0 B/op          0 allocs/op
BenchmarkMean4-32         771492              1514 ns/op               0 B/op          0 allocs/op
BenchmarkMean5-32            676           1536325 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/orvend/stats 8.409s