### PR TITLE
add median function

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -1,5 +1,9 @@
 package stats
 
+import (
+	"sort"
+)
+
 // Mean returns the mean of the slice.
 func Mean(input []float64) float64 {
 	if len(input) == 0 {
@@ -10,4 +14,25 @@ func Mean(input []float64) float64 {
 		sum += in
 	}
 	return sum / float64(len(input))
+}
+
+// Median returns the median of the slice
+func Median(input []float64) (output float64) {
+	if len(input) == 0 {
+		return 0
+	}
+	if len(input) == 1 {
+		return input[0]
+	}
+
+	sort.Float64s(input)
+	l := len(input)
+
+	if l%2 != 0 {
+		output = input[l/2]
+	} else {
+		output = (input[l/2] + input[l/2-1]) / 2
+	}
+
+	return output
 }

--- a/stats.go
+++ b/stats.go
@@ -1,14 +1,12 @@
 package stats
 
 import (
+	"math"
 	"sort"
 )
 
 // Mean returns the mean of the slice.
 func Mean(input []float64) float64 {
-	if len(input) == 0 {
-		return 0
-	}
 	sum := 0.0
 	for _, in := range input {
 		sum += in
@@ -16,16 +14,16 @@ func Mean(input []float64) float64 {
 	return sum / float64(len(input))
 }
 
-// Median returns the median of the slice
+// Median returns the median of the slice. Panics if the input is not sorted.
 func Median(input []float64) (output float64) {
-	if len(input) == 0 {
-		return 0
-	}
-	if len(input) == 1 {
-		return input[0]
+	if len(input) < 2 {
+		return math.NaN()
 	}
 
-	sort.Float64s(input)
+	if !sort.Float64sAreSorted(input) {
+		panic("stats: input is not sorted.")
+	}
+
 	l := len(input)
 
 	if l%2 != 0 {

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,6 +1,8 @@
 package stats
 
 import (
+	"fmt"
+	"math"
 	"math/rand"
 	"testing"
 )
@@ -14,14 +16,20 @@ func TestMean(t *testing.T) {
 		args args
 		want float64
 	}{
-		{"empty", args{[]float64{}}, 0},
+		{"empty", args{[]float64{}}, math.NaN()},
 		{"equal", args{[]float64{5.0, 5.0, 5.0}}, 5.0},
 		{"different", args{[]float64{5.0, 10.0, 0.0}}, 5.0},
 		{"different2", args{[]float64{5.0, 10.0}}, 7.5},
+		{"nan", args{[]float64{5.0, math.NaN()}}, math.NaN()},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Mean(tt.args.input); got != tt.want {
+			got := Mean(tt.args.input)
+			if math.IsNaN(got) || math.IsNaN(tt.want) {
+				if !math.IsNaN(got) || !math.IsNaN(tt.want) {
+					t.Errorf("Mean() = %v, want %v", got, tt.want)
+				}
+			} else if got != tt.want {
 				t.Errorf("Mean() = %v, want %v", got, tt.want)
 			}
 		})
@@ -58,16 +66,29 @@ func TestMedian(t *testing.T) {
 		{"odd case sorted", args{[]float64{1.0, 2.0, 3.0, 4.0, 5.0}}, 3.0},
 		{"even case unsorted", args{[]float64{4.0, 2.0, 1.0, 3.0}}, 2.5},
 		{"odd case unsorted", args{[]float64{4.0, 3.0, 5.0, 1.0, 2.0}}, 3.0},
-		{"empty case", args{[]float64{}}, 0},
-		{"single value case", args{[]float64{1.0}}, 1.0},
+		{"empty case", args{[]float64{}}, math.NaN()},
+		{"single value case", args{[]float64{1.0}}, math.NaN()},
 		{"two values case", args{[]float64{1.0, 9.0}}, 5.0},
+		{"nan", args{[]float64{math.NaN(), 5.0}}, math.NaN()},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Median(tt.args.input); got != tt.want {
+			defer handlepanic()
+			got := Median(tt.args.input)
+			if math.IsNaN(got) || math.IsNaN(tt.want) {
+				if !math.IsNaN(got) || !math.IsNaN(tt.want) {
+					t.Errorf("Median() = %v, want %v", got, tt.want)
+				}
+			} else if got != tt.want {
 				t.Errorf("Median() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func handlepanic() {
+	if r := recover(); r != nil {
+		fmt.Println("Recover", r)
 	}
 }
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -44,3 +44,47 @@ func BenchmarkMean2(b *testing.B) { benchmarkMean(2, b) }
 func BenchmarkMean3(b *testing.B) { benchmarkMean(10, b) }
 func BenchmarkMean4(b *testing.B) { benchmarkMean(1e3, b) }
 func BenchmarkMean5(b *testing.B) { benchmarkMean(1e6, b) }
+
+func TestMedian(t *testing.T) {
+	type args struct {
+		input []float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want float64
+	}{
+		{"even case sorted", args{[]float64{1.0, 2.0, 3.0, 4.0}}, 2.5},
+		{"odd case sorted", args{[]float64{1.0, 2.0, 3.0, 4.0, 5.0}}, 3.0},
+		{"even case unsorted", args{[]float64{4.0, 2.0, 1.0, 3.0}}, 2.5},
+		{"odd case unsorted", args{[]float64{4.0, 3.0, 5.0, 1.0, 2.0}}, 3.0},
+		{"empty case", args{[]float64{}}, 0},
+		{"single value case", args{[]float64{1.0}}, 1.0},
+		{"two values case", args{[]float64{1.0, 9.0}}, 5.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Median(tt.args.input); got != tt.want {
+				t.Errorf("Median() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func benchmarkMedian(len int, b *testing.B) {
+	s := make([]float64, len)
+	for e := 0; e <= len-1; e++ {
+		s[e] = rand.Float64()
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Median(s)
+	}
+}
+
+func BenchmarkMedian0(b *testing.B)   { benchmarkMean(0, b) }
+func BenchmarkMedian1(b *testing.B)   { benchmarkMean(1, b) }
+func BenchmarkMedian2(b *testing.B)   { benchmarkMean(2, b) }
+func BenchmarkMedian10(b *testing.B)  { benchmarkMean(10, b) }
+func BenchmarkMedian1e3(b *testing.B) { benchmarkMean(1e3, b) }
+func BenchmarkMedian1e6(b *testing.B) { benchmarkMean(1e6, b) }


### PR DESCRIPTION
Added function to calculate the Median, with tests and benchmarks

```
BenchmarkMedian0-32             339460308                3.20 ns/op            0 B/op          0 allocs/op
BenchmarkMedian1-32             374257449                2.98 ns/op            0 B/op          0 allocs/op
BenchmarkMedian2-32             289684899                4.36 ns/op            0 B/op          0 allocs/op
BenchmarkMedian10-32            134159515                9.66 ns/op            0 B/op          0 allocs/op
BenchmarkMedian1e3-32             751282              1547 ns/op               0 B/op          0 allocs/op
BenchmarkMedian1e6-32                824           1488819 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/orvend/stats 19.181s
```